### PR TITLE
Fixed a bug where if an upgrade level on a card didn't have an attack…

### DIFF
--- a/TU_Card_XML_Gen/Updater.cs
+++ b/TU_Card_XML_Gen/Updater.cs
@@ -347,9 +347,12 @@ namespace TUComparatorLibrary
                             upgrade.Add(new XElement("health", Convert.ToInt32(Math.Floor(scalingFactor * health))));
 
                             // remove the attack node, and replace it if needed.
-                            if (upgrade.XPathSelectElement("attack") != null)
+                            if (attack != -1)
                             {
-                                upgrade.XPathSelectElement("attack")?.Remove();
+                                if (upgrade.XPathSelectElement("attack") != null)
+                                {
+                                    upgrade.XPathSelectElement("attack")?.Remove();
+                                }
 
                                 upgrade.Add(new XElement("attack", Convert.ToInt32(Math.Floor(scalingFactor * attack))));
                             }


### PR DESCRIPTION
… stat defined already, the updater wouldn't give it an attack stat, which was breaking the scaling function and, in cases where the last level didn't have an attack stat defined, the end stats as well.